### PR TITLE
Correctly reference DOMDocument within namespace

### DIFF
--- a/Lib/Parsedown/ParsedownExtra.php
+++ b/Lib/Parsedown/ParsedownExtra.php
@@ -464,7 +464,7 @@ class ParsedownExtra extends Parsedown
         # http://stackoverflow.com/q/1148928/200145
         libxml_use_internal_errors(true);
 
-        $DOMDocument = new DOMDocument;
+        $DOMDocument = new \DOMDocument;
 
         # http://stackoverflow.com/q/11309194/200145
         $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');


### PR DESCRIPTION
Fixed: 
- DOMDocument call in ParsedownExtra::processTag no longer throws a "Class not found" error. 

Note: I know this is a third party include, but it's already forked to include a namespace here, and the original source has 111 outstanding PRs and hasn't been maintained for 2 years.